### PR TITLE
Add BHNT token

### DIFF
--- a/tokens-rin.json
+++ b/tokens-rin.json
@@ -1,12 +1,13 @@
 [
 {
-  "symbol":"",
-  "name":"",
-  "address":"",
-  "decimal":"",
+  "symbol":"BHNT",
+  "name":"Berlin Hack&Tell winner token",
+  "address":"0xe27826eE778B6F78a49a686dA7D64f6E7b084a4f",
+  "decimal":"0",
   "logo":"",
-  "support":"",
-  "community":"",
-  "website":""
+  "support":"ligi@ligi.de",
+  "community":"https://twitter.com/BerlinHacknTell",
+  "website":"http://berlin.hackandtell.org",
+  "github":"https://github.com/berlin-hack-and-tell"  
 }
 ]


### PR DESCRIPTION
This token is given to winners of  Berlin Hack&Tell - we started last month with our "ICO" - so only one token was passed on so far (to http://zells.org) - but we will now pass one on every month ;-)