### PR TITLE
Update urls-darklist.json - karbon.vacau.com

### DIFF
--- a/urls-darklist.json
+++ b/urls-darklist.json
@@ -1,5 +1,9 @@
 [
 {
+  "id":"karbon.vacau.com",
+  "comment":"Scam site of karbon.io"
+},
+{
   "id":"account-kigo.net",
   "comment":""
 },


### PR DESCRIPTION
Found the domain on a CryptoCompare forum.

![image](https://user-images.githubusercontent.com/2313704/28572485-2399a518-713f-11e7-8754-3c5173aa5aea.png)
