### PR TITLE
Update addresses-darklist - ziber.io

### DIFF
--- a/addresses-darklist.json
+++ b/addresses-darklist.json
@@ -1,5 +1,15 @@
 [
 {
+  "address":"0xf0a924661b0263e5ce12756d07f45b8668c53380",
+  "comment":"Ziber.io is now offline, this was their 'contract' address after their original one was suicide",
+  "date":"2017-07-28"
+},
+{
+  "address":"0xf0a924661b0263e5ce12756d07f45b8668c53380",
+  "comment":"Ziber.io original contract address, called suicide after about 1000eth",
+  "date":"2017-07-28"
+},
+{
   "address":"0xb3764761e297d6f121e79c32a65829cd1ddb4d32",
   "comment":"MultiSigExploit-Hacker_main",
   "date":"2017-07-20"


### PR DESCRIPTION
Adding to the darklist for reasons listed. Domain and socials are down. Funds moved from the original contract address and suicided. Suspected scam.