### PR TITLE
Removed aragon.one

### DIFF
--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -4,10 +4,6 @@
   "comment": "phishing site, stealing keys"
 },
 {
-  "id": "aragon.one",
-  "comment": "phishing site. https://twitter.com/AragonProject/status/902062846980317184"
-},
-{
   "id": "aragon.im",
   "comment": "phishing site, stealing keys, sending airdrop DM's in Slacks"
 },


### PR DESCRIPTION
Misunderstanding on the report. Aragon.one is their domain https://twitter.com/AragonProject/status/902177930436071424