### PR TITLE
etherdelta.gitnub.io

### DIFF
--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -1,5 +1,9 @@
 [
 {
+  "id": "etherdelta.gitnub.io",
+  "comment": "Fake etherdelta site, stealing private keys"
+},
+{
   "id": "kirkik.com",
   "comment": "Fake KIN (by KIK) crowdsale site - address: 0xF8E676094628776690DBf83fa31f08aA14FD3fb8"
 },


### PR DESCRIPTION
fake etherdelta site, stealing private keys.