### PR TITLE
myetherwalletlgn.com

### DIFF
--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -1,4 +1,7 @@
 [{
+"id":       "myetherwalletlgn.com",
+"comment":  "Phish. MEW."
+},{
 "id":       "raidens.network",
 "comment":  "Phish. Raiden. Fake crowdsale site"
 },{


### PR DESCRIPTION
myetherwalletlgn.com
Kaspersky marks this as phishing par virustotal site, while actual site now showing other than mew. 

![virustotal](https://user-images.githubusercontent.com/1669550/31921798-295cd24a-b8ac-11e7-9b83-b8f5161d2667.jpg)
 

Site screen shot here
![bitcoin_block_explorer_-_blockchain](https://user-images.githubusercontent.com/1669550/31921692-ae390796-b8ab-11e7-8981-a0d471326ea0.jpg)
