### PR TITLE
Two Mew Active Phish URLs

### DIFF
--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -1,4 +1,10 @@
 [{
+"id":       "www.xn--metherwallet-1vc.com",
+"comment":  "Phish. MEW."
+},{
+"id":       "myetherwalletjson.com",
+"comment":  "Phish. MEW."
+},{
 "id":       "rdrgh.com",
 "comment":  "Phish. MEW."
 },{


### PR DESCRIPTION
1) myetherwalletjson.com
2) xn--metherwallet-1vc.com 

**Both passed through Metamask and EAL**

# **1) myetherwalletjson.com**

![slack_-_eventchain](https://user-images.githubusercontent.com/1669550/32371898-a902813c-c060-11e7-81f1-03c055eeb919.jpg)


![myetherwallet_and_slack_-_eventchain](https://user-images.githubusercontent.com/1669550/32371957-e3e75e62-c060-11e7-90bb-c37e13e3fb55.jpg)

![fullscreen_2017_11_03_6_08](https://user-images.githubusercontent.com/1669550/32371985-00cbacae-c061-11e7-9946-fef85a477fe2.jpg)


# **2) xn--metherwallet-1vc.com**

![fullscreen_2017_11_03_5_59](https://user-images.githubusercontent.com/1669550/32372115-8115492e-c061-11e7-84b6-57fbdec945d4.jpg)


![fullscreen_2017_11_03_6_03](https://user-images.githubusercontent.com/1669550/32372137-9ff59e84-c061-11e7-9254-03fb2c45a2d1.jpg)

# **At below shot, URL in address bar does not have caret ^, probably re-direct to genuine?**

![fullscreen_2017_11_03_6_48](https://user-images.githubusercontent.com/1669550/32372766-41bf489e-c064-11e7-99b8-5bfb19f0728b.jpg)



 
