### PR TITLE
coinbasenews.co.uk phish

### DIFF
--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -1,5 +1,5 @@
 [{
-id":       "coinbasenews.co.uk",
+"id":       "coinbasenews.co.uk",
 "comment":  "Phish. coinbase.com, along with mÿetherwallet dot com"
 },{ 
 "id":       "xn--myetherallet-4k5fwn.com",

--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -1,4 +1,7 @@
 [{
+id":       "coinbasenews.co.uk",
+"comment":  "Phish. coinbase.com, along with mÿetherwallet dot com"
+},{ 
 "id":       "xn--myetherallet-4k5fwn.com",
 "comment":  "Phish. MEW"
 },{ 


### PR DESCRIPTION
coinbasenews.co.uk  -  Phishing URL captured 

Shown at dm at eventchain slack 
https://eventchain.slack.com/messages/D84SJJNUV/   (Probably multiple destination)

![kvh_nuke___eventchain_slack_and_tradingview_chart_widget](https://user-images.githubusercontent.com/1669550/33192010-759e17a4-d102-11e7-82d3-31d4fdfb0126.jpg)

EAL block this succeeding mew phish URL, so remove EAL, then 

http://mÿetherwallet.com/signin.php?sessid=1494acc0e6e73578fa2f7d344b9cda85&tok=7c112173efca4899213c618484d8f5fe&api=a19f89113e392bb944d3ec0796340fbd&tls=d7be708e7945ebab11a34c530cb4dchttps://coinbase.co.com/

![coinbase_-_buy_sell_digital_currency](https://user-images.githubusercontent.com/1669550/33191943-e8dc1cc6-d101-11e7-824b-e2c25d60b71e.jpg)


Reported at ggl and virustotal already. 
