### PR TITLE
Added RiPT Token to Defaults

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -7135,6 +7135,38 @@
   "youtube"   : ""
 }
 },{
+"symbol"      : "RIPT",
+"address"     : "0xdd007278b667f6bef52fd0a4c23604aa1f96039a",
+"decimals"    : "8",
+"name"        : "RIPTIDECOIN",
+"ens_address" : "",
+"website"     : "https://riptidecoin.com/",
+"logo": {
+  "src"       : "https://etherscan.io/token/images/riptide_28.png",
+  "width"     : "24",
+  "height"    : "24",
+  "ipfs_hash" : ""
+},
+"support": {
+  "email"     : "support@riptidecoin.com",
+  "url"       : ""
+},
+"social": {
+  "blog"      : "",
+  "chat"      : "",
+  "facebook"  : "https://www.facebook.com/RiptideCoin/",
+  "fourm"     : "",
+  "github"    : "https://github.com/riptidecoin/riptide-coin",
+  "gitter"    : "riptidecoin",
+  "instagram" : "https://www.instagram.com/riptide_coin/",
+  "linkedin"  : "",
+  "reddit"    : "",
+  "slack"     : "https://mmjfintech.slack.com",
+  "telegram"  : "",
+  "twitter"   : "https://twitter.com/RiptideCoin",
+  "youtube"   : ""
+}
+},{
 "symbol"      : "RLC",
 "address"     : "0x607F4C5BB672230e8672085532f7e901544a7375",
 "decimals"    : "9",


### PR DESCRIPTION
Hello thank you for your support. More accurate charts and pricing for us available on cryptocompare's api https://www.cryptocompare.com/coins/ript/overview because we are trading less than coin marketcap. com's 10k per day minimum for erc20 tokens. This hurts starup Ico growth for us. wish you could pull ours from cryptocompare like we had to use as other sources to bring live charts to our users before the 10k daily volume needed for coincap.  Our trade volume comes from etherdelta exchange https://etherdelta.com/#RIPT-ETH  thank you team MEW!