### PR TITLE
Updated SXD / SXU Token to Defaults

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -9021,10 +9021,10 @@
   "youtube"   : ""
 }
 },{
-"symbol"      : "SXD",
-"address"     : "0x554c98b3ec772f79eE5b96d47A1D10852ED274C8",
+"symbol"      : "SXDT",
+"address"     : "0x12b306fa98f4cbb8d4457fdff3a0a0a56f07ccdf",
 "decimals"    : "18",
-"name"        : "SXD",
+"name"        : "Spectre.ai D-Token",
 "ens_address" : "",
 "website"     : "www.spectre.ai",
 "logo": {
@@ -9053,10 +9053,10 @@
   "youtube"   : ""
 }
 },{
-"symbol"      : "SXU",
-"address"     : "0xaADB05F449072D275833bAf7C82e8fCa4ee46575",
+"symbol"      : "SXUT",
+"address"     : "0x2c82c73d5b34aa015989462b2948cd616a37641f",
 "decimals"    : "18",
-"name"        : "SXU",
+"name"        : "Spectre.ai U-Token",
 "ens_address" : "",
 "website"     : "www.spectre.ai",
 "logo": {


### PR DESCRIPTION
SXD and SXU tokens were reissued as SXDT and SXUT by spectre.ai.

Updated token addresses to match:
https://medium.com/teamspectreai/ico-over-and-token-conversion-update-d8ab803fe8d3