### PR TITLE
added BitClave CAT

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -1696,7 +1696,7 @@
 }
 },{
 "symbol"      : "CAT (BitClave)",
-"address"     : "0x111111f7e9B1Fe072ade438F77E1Ce861C7eE4E3",
+"address"     : "0x1234567461d3f8db7496581774bd869c83d51c93",
 "decimals"    : "18",
 "name"        : "CAT (BitClave)",
 "ens_address" : "",
@@ -1730,7 +1730,7 @@
 "symbol"      : "CATs (BitClave)",
 "address"     : "0x68e14bb5A45B9681327E16E528084B9d962C1a39",
 "decimals"    : "18",
-"name"        : "CAT (BitClave)",
+"name"        : "CATs (BitClave)",
 "ens_address" : "",
 "website"     : "https://www.bitclave.com",
 "logo": {


### PR DESCRIPTION
updating address for the final CAT (BitClave) token
Official Blog with address announcement for CAT v.2 is here https://medium.com/@BitClave/adding-cat-tokens-to-your-wallet-a1771fbe513d