### PR TITLE
Updating wrong symbol for Envion "ENV" to "EVN"

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -3905,7 +3905,7 @@
   "youtube"   : ""
 }
 },{
-"symbol"      : "ENV",
+"symbol"      : "EVN",
 "address"     : "0xd780Ae2Bf04cD96E577D3D014762f831d97129d0",
 "decimals"    : "18",
 "name"        : "Envion AG",


### PR DESCRIPTION
#357
Updating wrong symbol for Envion "ENV" to "EVN" as described in
https://ethereum.stackexchange.com/questions/36132/envion-token-show-up-as-env-instead-of-evn/36145#36145