### PR TITLE
Add ddengle.com , youbit.co.kr , and ethersocial.org as a scam list

### DIFF
--- a/emails/emails-darklist.json
+++ b/emails/emails-darklist.json
@@ -32,5 +32,7 @@
 "vonda13-8@yahoo.co.uk",
 "vonda1983@btinternet.com",
 "vonda1983@btopenworld.com",
-"vonda1989@bitinternet.com"
+"vonda1989@bitinternet.com",
+"ddengleinfo@gmail.com",
+"ethersocialcoin@gmail.com"
 ]

--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -7102,4 +7102,16 @@
 },{
 "id":       "https://smartcontractlink.com",
 "comment":  "SmartContract/LINK fake crowdsale site"
+},{
+"id":       "ddengle.com",
+"comment":  "Coin scam-ddengle"
+},{
+"id":       "youbit.co.kr",
+"comment":  "Coin scam-ddengle"
+},{
+"id":       "ethersocial.org",
+"comment":  "Coin scam-ddengle"
+},{
+"id":       "https://escwallet-kr.gonsmine.com",
+"comment":  "Coin scam-ddengle"
 }]


### PR DESCRIPTION
**WARNING** Those scammer has been active at github.com! Please be careful!
https://github.com/ethersocial (Scam coin repository)
https://github.com/hackmod (He is a real hacker be careful!)

+ Why it is a scam
https://youbit.co.kr is a scam website that is running by someone who owns "ddengle.com", a scam website with many ICO and miner ASIC scammers on it. 

The site told that they have been hacked by a north-korean hackers https://www.coindesk.com/south-korean-bitcoin-exchange-declare-bankruptcy-hack/ however it is operating normally without any refunds or any apology.

Instead, they made a coin called "EtherSocial" coin, assuming that it has been backed up by those un-withdrawned funds. 

So me and our community, gazua.tv has decided to save users ,miners and those earlier investors as a chain-split, and by Feb 14 the new, shiny coin revealed without any possibility of fraud or scam. 

The new coin, "Ethereum Social" will be backed up by a newer interface and newer servers, etc.

However, after the fork, there has been such a scam marketers and those advocate who still believes the show and we need a help in order to defense them.

Therefore, I am suggesting that we should ban them from the open-source community and therefore they should not advertise or sell their scam tokens.