### PR TITLE
add ENTRP to tokens

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -15869,5 +15869,37 @@
     "twitter": "https://twitter.com/polyswarm",
     "youtube": "https://www.youtube.com/channel/UClkA8JVQ--oMsPomOKM85fA"
   }
+},
+  {
+  "symbol": "ENTRP",
+  "address": "0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3",
+  "decimals": 18,
+  "name": "Hut34 Entropy Token",
+  "ens_address": "",
+  "website": "https://hut34.io/",
+  "logo": {
+    "src": "https://hut34.io/images/comms/Hut34-logo-orange.jpg",
+    "width": "300",
+    "height": "300"
+  },
+  "support": {
+    "email": "admin@hut34.io",
+    "url": ""
+  },
+  "social": {
+    "blog": "https://medium.com/@hut34project",
+    "chat": "",
+    "facebook": "https://www.facebook.com/hut34project",
+    "forum": "",
+    "github": "https://github.com/hut34",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "https://www.linkedin.com/company/18132913/",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/hut34",
+    "twitter": "https://twitter.com/hut34project",
+    "youtube": "https://www.youtube.com/channel/UCiemFFyT2Sv2ulrRQfNI89Q"
+  }
 }
 ]


### PR DESCRIPTION
The Hut34 Project is building a blockchain based protocol to facilitate the open exchange and monetization of data, information and digital services. It’s where A.I does business: An ecosystem of chatbots, A.I. and IoT services where developers can easily connect and route queries, receive resolution of these queries, add utility to their end users, and be fairly rewarded for this. The Entropy Token is a utility token, that powers the Hut34 Protocol and Network.