### PR TITLE
Added DOW Token to Defaults

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -4480,11 +4480,11 @@
 }
 },{
 "symbol"      : "DOW",
-"address"     : "0xEEF6E90034eEa89E31Eb4B8eaCd323F28A92eaE4",
+"address"     : "0x76974c7b79dc8a6a109fd71fd7ceb9e40eff5382",
 "decimals"    : "18",
 "name"        : "DOW",
 "ens_address" : "",
-"website"     : "https://www.dowico.com",
+"website"     : "https://dowcoin.io/",
 "logo": {
   "src"       : "",
   "width"     : "",
@@ -4492,7 +4492,7 @@
   "ipfs_hash" : ""
 },
 "support": {
-  "email"     : "info@dowico.com",
+  "email"     : "dowcoin@gmail.com",
   "url"       : ""
 },
 "social": {


### PR DESCRIPTION
Due to some reasons we need to change the contract address of our token. We have updated the new contract address and website link. Now we are using the new token address and discarded the previous one.