### PR TITLE
Update COSS token address

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -3200,7 +3200,7 @@
 }
 },{
 "symbol"      : "COSS",
-"address"     : "0x65292eeadf1426cd2df1c4793a3d7519f253913b",
+"address"     : "0x9e96604445ec19ffed9a5e8dd7b50a29c899a10c",
 "decimals"    : "18",
 "name"        : "Coss Token",
 "ens_address" : "",


### PR DESCRIPTION
The COSS token forked on 04.03.2018 to the ERC223 standard. You can find more at the official announcement on:

https://coss.io/coss-token-update