### PR TITLE
Added CLL Token to Defaults

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -2654,6 +2654,31 @@
 		}
 	},
 	{
+		"symbol": "CLL",
+		"address": "0x3dc9a42fa7afe57be03c58fd7f4411b1e466c508",
+		"decimals": 18,
+		"name": "CryptoLiveLeak",
+		"ens_address": "",
+		"website": "https://www.cryptoliveleak.com/",
+		"logo": { "src": "https://github.com/CryptoLiveLeak/CLL-Token/blob/master/28%20x%2028%20CLL%20png.png", "width": "28", "height": "28", "ipfs_hash": "" },
+		"support": { "email": "contactus@cryptoliveleak.com", "url": "" },
+		"social": {
+			"blog": "https://medium.com/@cryptoliveleak",
+			"chat": "",
+			"facebook": "https://www.facebook.com/CryptoLiveLeak/",
+			"forum": "",
+			"github": "https://github.com/CryptoLiveLeak/CLL-Token",
+			"gitter": "",
+			"instagram": "https://www.instagram.com/cryptoliveleak/",
+			"linkedin": "",
+			"reddit": "https://www.reddit.com/r/CryptoLiveLeak/",
+			"slack": "",
+			"telegram": "https://t.me/CryptoLiveLeak",
+			"twitter": "https://twitter.com/CryptoLiveLeak",
+			"youtube": "https://www.youtube.com/channel/UCeoB_bpoVOcwIh-MSLxzNpA"
+		}
+	},
+	{
 		"symbol": "CLN",
 		"address": "0x4162178B78D6985480A308B2190EE5517460406D",
 		"decimals": 18,


### PR DESCRIPTION
Token is currently trading here: https://forkdelta.github.io/#!/trade/CLL-ETH

Description:
CryptoLiveLeak is a leading cryptocurrency news and media platform. We have integrated the CLL token with our platform to innovative ways the audience and media interact. The CLL Token has multiple benefits including exclusive discounts when participating in future ICOs from founder or through the CryptoLiveLeak platform. We have a large dedication to giving the CLL tokens to those who interact with our platform as show by our Airdrop and Giveaways. Token holders can also accumulate a LEAK SCORE to gain additional incentives when interacting with the CryptoLiveLeak platform. We aim to innovate and disrupt in a variety of industries and want our early supporters to gain with us by holding CLL token. This all occurs within a trustless environment where all participants have transparency. The platform will evolve as we progress with IBO efforts. The CryptoLiveLeak team will also look to expand and grow as the network matures. Large budget for development and marketing. The CryptoLiveLeak (CLL) ERC20 token will give holders an unique way of participating in the evolution of our vision of blockchain tech including transforming the payment and exchanges industries.