### PR TITLE
Added EPX and ARXT Tokens to Defaults

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -756,6 +756,31 @@
 		}
 	},
 	{
+		"symbol": "ARXT",
+		"address": "0xb0D926c1BC3d78064F3e1075D5bD9A24F35Ae6C5",
+		"decimals": 18,
+		"name": "Assistive Reality ARX",
+		"ens_address": "",
+		"website": "https://aronline.io",
+		"logo": { "src": "https://aronline.io/wp-content/uploads/2018/01/favicon.png", "width": "100", "height": "100", "ipfs_hash": "" },
+		"support": { "email": "staff@aronline.io", "url": "https://aronline.io/" },
+		"social": {
+			"blog": "",
+			"chat": "",
+			"facebook": "https://www.facebook.com/AssistiveReality/",
+			"forum": "",
+			"github": "https://github.com/va109/Artex",
+			"gitter": "",
+			"instagram": "https://www.instagram.com/AssistiveReality/",
+			"linkedin": "https://www.linkedin.com/in/assistive-reality/",
+			"reddit": "",
+			"slack": "",
+			"telegram": "https://t.me/AssistiveReality_ARX",
+			"twitter": "https://twitter.com/aronline_io/",
+			"youtube": ""
+		}
+	},
+	{
 		"symbol": "AST",
 		"address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
 		"decimals": 4,
@@ -4705,6 +4730,31 @@
 			"slack": "",
 			"telegram": "",
 			"twitter": "",
+			"youtube": ""
+		}
+	},
+	{
+		"symbol": "EPX",
+		"address": "0x35BAA72038F127f9f8C8f9B491049f64f377914d",
+		"decimals": 4,
+		"name": "ethPoker.io EPX",
+		"ens_address": "",
+		"website": "https://ethPoker.io",
+		"logo": { "src": "https://ethpoker.io/wp-content/uploads/2018/03/smallBlueIcon.png", "width": "51", "height": "50", "ipfs_hash": "" },
+		"support": { "email": "admin@ethPoker.io", "url": "https://ethPoker.io" },
+		"social": {
+			"blog": "https://ethpoker.io/",
+			"chat": "",
+			"facebook": "",
+			"forum": "",
+			"github": "https://github.com/EthPokerIO/ethpokerIO",
+			"gitter": "",
+			"instagram": "",
+			"linkedin": "https://www.linkedin.com/in/ethpoker/",
+			"reddit": "",
+			"slack": "",
+			"telegram": "https://t.me/EthPokerIOpresale",
+			"twitter": "https://twitter.com/ethpoker",
 			"youtube": ""
 		}
 	},


### PR DESCRIPTION
We are running a huge AirDrop for ethPoker.io EPX tokens, so we have added these to the list.
Also added are our other Assistive Reality ARXT tokens. We requested those under ARX ticker previously but another user kinda stole our ticker, so we will use ARXT on MEW.
Both are carefully added. Please action ASAP as we're about 4 days away from issuing the tokens via AirDrop and would like MEW users (most of our users) to see the token properly. 
Pls contact admin@ethpoker.io if there are issues with this.
Using our main Git account (Assistive Reality) to do this pull request/change.