### PR TITLE
fix: make PATH address ERC55 compliant

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -9463,7 +9463,7 @@
 	},
 	{
 		"symbol": "PATH",
-		"address": "0xf813f3902bbc00a6dce378634d3b79d84f9803d7",
+		"address": "0xF813F3902bBc00A6DCe378634d3B79D84F9803d7",
 		"decimals": 18,
 		"name": "PATH",
 		"ens_address": "",


### PR DESCRIPTION
the previous address was not ERC55 compliant, apologies!