### PR TITLE
Correct decimal count for Globitex

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -5849,7 +5849,7 @@
 	{
 		"symbol": "GBX",
 		"address": "0x12fCd6463E66974cF7bBC24FFC4d40d6bE458283",
-		"decimals": 18,
+		"decimals": 8,
 		"name": "Globitex",
 		"ens_address": "",
 		"website": "https://www.globitexico.com",


### PR DESCRIPTION
Globitex uses non-standard 8 decimals for their tokens, not 18.