### PR TITLE
[tokens] changed PAT to XPAT

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -12143,7 +12143,7 @@
 		}
 	},
 	{
-		"symbol": "PAT",
+		"symbol": "XPAT",
 		"address": "0xBB1fA4FdEB3459733bF67EbC6f893003fA976a82",
 		"decimals": 18,
 		"name": "Pangea Arbitration Token",


### PR DESCRIPTION
Hi.
We are rebranding our token PAT as XPAT the rest stays as it is.