### PR TITLE
[Readd] Add EOSC impersonation scam

### DIFF
--- a/addresses/addresses-darklist.json
+++ b/addresses/addresses-darklist.json
@@ -3443,5 +3443,35 @@
 		"comment":
 			"Scam address of phishing email sent to leaked Everex investor database",
 		"date": "2017-09-05"
+	},
+	{
+		"address": "0xcdcf7570e27fe31ad5c6d4c8c7d78d98507d649d",
+		"comment":
+			"Scam address of impersonating EOS Classic Coin https://eos-classic.io",
+		"date": "2018-06-21"
+	},
+	{
+		"address": "0xce3ad07c9c7a5f89d39eb1449913d3feecabcf8d",
+		"comment":
+			"Scam address of impersonating EOS Classic Coin https://eos-classic.io",
+		"date": "2018-06-21"
+	},
+	{
+		"address": "0xdbfebf00f4601c176bdb61bf65f2abc9e213e065",
+		"comment":
+			"Scam address of impersonating EOS Classic Coin https://eos-classic.io",
+		"date": "2018-06-21"
+	},
+	{
+		"address": "0x1a18c7ff9369351d41db980fac5c1036b4b9e125",
+		"comment":
+			"Scam address of impersonating EOS Classic Coin https://eos-classic.io",
+		"date": "2018-06-21"
+	},
+	{
+		"address": "0x00ae2c6da8eed2c17f1b6e1b6a4e104ff12e7e5f",
+		"comment":
+			"Scam address of impersonating EOS Classic Coin https://eos-classic.io",
+		"date": "2018-06-21"
 	}
 ]

--- a/urls/urls-darklist.json
+++ b/urls/urls-darklist.json
@@ -815,6 +815,9 @@
 "id":       "eos-io.info",
 "comment":  "Scam: EOS"
 },{
+"id":       "eosclassic.co",
+"comment":  "Scam: EOS Classic Impersonation (eos-classic.io)"
+},{
 "id":       "blocklichan.info",
 "comment":  ""
 },{


### PR DESCRIPTION
eos-classic.io was the first project to use the symbol "EOS Classic" and the ticker "EOSC". In the case of "Bitcoin Classic" or "Bitcoin Clashic (Yes this is the fork of Bitcoin Cash) ", avoiding the use of same ticker or same coin name is a strict rule, in order to prevent name conflict on the services like CoinMarketCap or Coin exchanges. Also there is the case that exchanges and services changed the ticker of bitcoin cash from "BCC" to "BCH" in order to avoid conflict on trading coins. 

**Therefore using the same coin name on the different coin architecture or project must be avoided in a same manner.**

If @EOSclassic-EOSC you guys or team are planning to create a valid project for creating the token, please change your coin name or token to different symbol that avoids conflict with our team.

If the changes are not done by a reasonable time our team will report eosclassic.co or the following token https://etherscan.io/address/0xce3ad07c9c7a5f89d39eb1449913d3feecabcf8d as a illegal impersonation of EOS Classic [EOSC] coin which will be available on the next release of MyEtherWallet or MyCrypto.

**Requesting to readd the commit in order to avoid conflict and since our "EOS Classic" team and the official project exists I think the warning message should not removed without enough consensus with us.**