### PR TITLE
Update Lemo token address

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -9822,7 +9822,7 @@
 	},
 	{
 		"symbol": "LEMO",
-		"address": "0xB5AE848EdB296C21259b7467331467d2647eEcDf",
+		"address": "0x60C24407d01782C2175D32fe7C8921ed732371D1",
 		"decimals": 18,
 		"name": "Lemo",
 		"ens_address": "",
@@ -9843,7 +9843,7 @@
 			"gitter": "",
 			"instagram": "",
 			"linkedin": "",
-			"reddit": "",
+			"reddit": "https://www.reddit.com/user/LemoChain",
 			"slack": "",
 			"telegram": "https://t.me/lemochain",
 			"twitter": "https://twitter.com/LemoChain",


### PR DESCRIPTION
We have to upgrade Lemo token contract to prevent security vulnerability.
This is the upgrade detail: https://github.com/LemoFoundationLtd/lemo-contracts/pull/10
And an announcement is placed on our [website](https://www.lemochain.com)

The old token is deployed by me at #431 . 
Thank you for help me