### PR TITLE
Update aXpire token contract address

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -1409,10 +1409,10 @@
 		}
 	},
 	{
-		"symbol": "AXP",
-		"address": "0x9af2c6B1A28D3d6BC084bd267F70e90d49741D5B",
-		"decimals": 8,
-		"name": "AXP",
+		"symbol": "AXPR",
+		"address": "0xC39E626A04C5971D770e319760D7926502975e47",
+		"decimals": 18,
+		"name": "AXPR",
 		"ens_address": "",
 		"website": "https://www.axpire.io/",
 		"logo": { "src": "", "width": "", "height": "", "ipfs_hash": "" },
@@ -1422,7 +1422,7 @@
 			"chat": "",
 			"facebook": "https://www.facebook.com/Axpire-537274833301303",
 			"forum": "",
-			"github": "",
+			"github": "https://github.com/axpire/",
 			"gitter": "",
 			"instagram": "",
 			"linkedin": "",


### PR DESCRIPTION
Old AXP token is being replaced with AXPR token: See the official announcement here: https://twitter.com/aXpire_official/status/1017442224978710529