### PR TITLE
Update decimal places to 0 for VDG token

### DIFF
--- a/tokens/tokens-eth.json
+++ b/tokens/tokens-eth.json
@@ -17286,7 +17286,7 @@
 			"chat": "",
 			"facebook": "https://www.facebook.com/VeriDocGlobal",
 			"forum": "",
-			"github": "https://github.com/VeriDocGlobal",
+			"github": "https://github.com/VeriDocGlobal", 
 			"gitter": "",
 			"instagram": "https://www.instagram.com/VeriDocGlobal/",
 			"linkedin": "https://www.linkedin.com/company/veridocglobal",


### PR DESCRIPTION
Please treat VDG token decimal places to 0 as currently all clients balance displaying in decimal format like
1.5206018374e-8	VDG