### PR TITLE
Fake copy of ROCK2 token

### DIFF
--- a/src/addresses/addresses-darklist.json
+++ b/src/addresses/addresses-darklist.json
@@ -1,5 +1,10 @@
 [
   {
+    "address": "0x8abe0a9b8A1C8a003354E61F3ed8befdeb7D2CEc",
+    "comment": "Fake copy of ROCK2 token",
+    "date": "2018-09-12"
+  },
+  {
     "address": "0xfb6E71e0800BcCC0db8a9Cf326fe3213CA1A0EA0",
     "comment": "Scam lottery contract that takes advantage of odd struct memory management",
     "date": "2018-06-19"


### PR DESCRIPTION
This is fake copy of ROCK2 token, some hints:
- was created after original ROCK2 token, it uses exactly same token symbol and token name as the original one
- has 7 holders compared to original 7337 holders
- it was created probably to have fake token.store page, where are set offers, luckily no actual trades