### PR TITLE
Fixes token format; Address contained a name value 💩

### DIFF
--- a/src/tokens/eth/0x6f259637dcd74c767781e37bc6133cd6a68aa161.json
+++ b/src/tokens/eth/0x6f259637dcd74c767781e37bc6133cd6a68aa161.json
@@ -1,8 +1,8 @@
 {
   "symbol": "HT",
-  "name": "HT",
+  "name": "HuobiToken",
   "type": "ERC20",
-  "address": "HuobiToken",
+  "address": "0x6f259637dcd74c767781e37bc6133cd6a68aa161",
   "ens_address": "",
   "decimals": 18,
   "website": "",


### PR DESCRIPTION
Your CI didn't catch this one.