### PR TITLE
Another ROCK2 and ROCK2PAY fake tokens

### DIFF
--- a/src/addresses/addresses-darklist.json
+++ b/src/addresses/addresses-darklist.json
@@ -1,5 +1,15 @@
 [
   {
+    "address": "0xcc02b920ae227f1be7d01fc241c27e5f74d40436",
+    "comment": "Fake copy of ROCK2 token",
+    "date": "2018-10-28"
+  },
+  {
+    "address": "0xa153a6eF80fb5d60de18688bdC82684d48FC8De1",
+    "comment": "Fake copy of ROCK2 token",
+    "date": "2018-10-28"
+  },
+  {
     "address": "0x19fb7020381fe9197bf841d5034D5467FE5a3C93",
     "comment": "Fake copy of ROCK2 token",
     "date": "2018-10-27"

--- a/src/addresses/addresses-darklist.json
+++ b/src/addresses/addresses-darklist.json
@@ -1,5 +1,10 @@
 [
   {
+    "address": "0x19fb7020381fe9197bf841d5034D5467FE5a3C93",
+    "comment": "Fake copy of ROCK2 token",
+    "date": "2018-10-27"
+  },
+  {
     "address": "0x8abe0a9b8A1C8a003354E61F3ed8befdeb7D2CEc",
     "comment": "Fake copy of ROCK2 token",
     "date": "2018-09-12"

--- a/src/addresses/addresses-darklist.json
+++ b/src/addresses/addresses-darklist.json
@@ -1,5 +1,10 @@
 [
   {
+    "address": "0xF193a9aFb00715AaCF7ca9Ebffafe02C77517C2E",
+    "comment": "Fake copy of ROCK2PAY token",
+    "date": "2018-11-06"
+  },
+  {
     "address": "0xcc02b920ae227f1be7d01fc241c27e5f74d40436",
     "comment": "Fake copy of ROCK2 token",
     "date": "2018-10-28"


### PR DESCRIPTION
Again, same symbol and same name as original, but wrong decimals, 100M total supply (oriignal is 15M) and 8 holders, compared to 7100 of original ROCK2.