### PR TITLE
Fix WIB token decimals

### DIFF
--- a/src/tokens/eth/0x3F17Dd476faF0a4855572F0B6ed5115D9bBA22AD.json
+++ b/src/tokens/eth/0x3F17Dd476faF0a4855572F0B6ed5115D9bBA22AD.json
@@ -4,7 +4,7 @@
   "type": "ERC20",
   "address": "0x3F17Dd476faF0a4855572F0B6ed5115D9bBA22AD",
   "ens_address": "",
-  "decimals": 18,
+  "decimals": 9,
   "website": "https://wibson.org",
   "logo": { "src": "", "width": "", "height": "", "ipfs_hash": "" },
   "support": {


### PR DESCRIPTION
There was an issue with the original amount of decimals. I was the one that uploaded WIB token in https://github.com/MyEtherWallet/ethereum-lists/pull/950. 