### PR TITLE
Correct Raiden Network spelling

### DIFF
--- a/src/tokens/eth/0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6.json
+++ b/src/tokens/eth/0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6.json
@@ -1,6 +1,6 @@
 {
   "symbol": "RDN",
-  "name": "Radien Network",
+  "name": "Raiden Network",
   "type": "ERC20",
   "address": "0x255aa6df07540cb5d3d297f0d0d4d84cb52bc8e6",
   "ens_address": "",


### PR DESCRIPTION
https://raiden.network