### PR TITLE
Add Neutral Dollar to MEW Default List

### DIFF
--- a/src/tokens/eth/0x0C6144c16af288948C8fdB37fD8fEc94bfF3d1d9.json
+++ b/src/tokens/eth/0x0C6144c16af288948C8fdB37fD8fEc94bfF3d1d9.json
@@ -1,0 +1,31 @@
+{
+  "symbol": "NUSD",
+  "name": "Neutral Dollar",
+  "type": "ERC20",
+  "address": "0x0C6144c16af288948C8fdB37fD8fEc94bfF3d1d9",
+  "ens_address": "",
+  "decimals": 6,
+  "website": "https://neutralproject.com",
+  "logo": {
+    "src": "https://neutralproject.com/images/logos/nusd.png",
+    "width": "300",
+    "height": "300",
+    "ipfs_hash": ""
+  },
+  "support": { "email": "hello@neutralproject.com", "url": "https://neutralproject.com" },
+  "social": {
+    "blog": "https://blog.neutralproject.com",
+    "chat": "",
+    "facebook": "https://www.facebook.com/Neutral-Project-391548818084169/",
+    "forum": "",
+    "github": "https://github.com/NeutralGroup",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "https://www.linkedin.com/company/neutralproject",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/neutralproject",
+    "twitter": "https://twitter.com/neutral_project",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
Neutral Dollar is listed and trading on [KuCoin](https://www.kucoin.com/news/en-neutral-dollar-nusd-gets-listed-on-kucoin-world-premiere) and [DDEX](https://medium.com/ddex/neutral-dollar-nusd-a-diversified-basket-of-stablecoins-announces-ddex-exchange-listing-33c3134bf1da).

[Etherscan Token Tracker for NUSD](https://etherscan.io/token/0x0C6144c16af288948C8fdB37fD8fEc94bfF3d1d9)