### PR TITLE
Fix aeternity symbol in the Kovan network

### DIFF
--- a/src/tokens/kov/0x8667559254241dded4d11392f868d72092765367.json
+++ b/src/tokens/kov/0x8667559254241dded4d11392f868d72092765367.json
@@ -1,5 +1,5 @@
 {
-  "symbol": "Aeternity",
+  "symbol": "AE",
   "name": "Aeternity",
   "type": "ERC20",
   "address": "0x8667559254241ddeD4d11392f868d72092765367",


### PR DESCRIPTION
It seems that in the /tokens/eth this is okay, but here in the Kovan network's there's a typo.