### PR TITLE
update dForce USDx and DF logo links

### DIFF
--- a/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
+++ b/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
@@ -2,7 +2,7 @@
   "symbol": "DF",
   "name": "dForce Platform Token",
   "type": "ERC20",
-  "address": "0xeb269732ab75a6fd61ea60b06fe994cd32a83549",
+  "address": "0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0",
   "ens_address": "",
   "decimals": 18,
   "website": "https://dforce.network",

--- a/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
+++ b/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
@@ -7,7 +7,7 @@
   "decimals": 18,
   "website": "https://dforce.network",
   "logo": {
-    "src": "https://github.com/dforcenetwork/docs/blob/master/logos/logo_DF.png",
+    "src": "https://dforce.network/logo_DF_256x256.png",
     "width": "256px",
     "height": "256px",
     "ipfs_hash": ""

--- a/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
+++ b/src/tokens/eth/0x431ad2ff6a9c365805ebad47ee021148d6f7dbe0.json
@@ -2,7 +2,7 @@
   "symbol": "DF",
   "name": "dForce Platform Token",
   "type": "ERC20",
-  "address": "0x431ad2ff6a9C365805eBaD47Ee021148d6f7DBe0",
+  "address": "0xeb269732ab75a6fd61ea60b06fe994cd32a83549",
   "ens_address": "",
   "decimals": 18,
   "website": "https://dforce.network",

--- a/src/tokens/eth/0xeb269732ab75a6fd61ea60b06fe994cd32a83549.json
+++ b/src/tokens/eth/0xeb269732ab75a6fd61ea60b06fe994cd32a83549.json
@@ -2,12 +2,12 @@
   "symbol": "USDx",
   "name": "dForce Stablecoin",
   "type": "ERC20",
-  "address": "0xeb269732ab75A6fD61Ea60b06fE994cD32a83549",
+  "address": "0xeb269732ab75a6fd61ea60b06fe994cd32a83549",
   "ens_address": "",
   "decimals": 18,
   "website": "https://dforce.network",
   "logo": {
-    "src": "https://github.com/dforcenetwork/docs/blob/master/logos/logo_USDx.png",
+    "src": "https://dforce.network/logo_USDx_256x256.png",
     "width": "256px",
     "height": "256px",
     "ipfs_hash": ""


### PR DESCRIPTION
Maybe pervious logo links do not work. I can't get logos in MEW. 