### PR TITLE
Add TrueHKD

### DIFF
--- a/src/tokens/eth/0x0000852600CEB001E08e00bC008be620d60031F2.json
+++ b/src/tokens/eth/0x0000852600CEB001E08e00bC008be620d60031F2.json
@@ -1,0 +1,31 @@
+{
+  "symbol": "THKD",
+  "name": "TrueHKD",
+  "type": "ERC20",
+  "address": "0x0000852600CEB001E08e00bC008be620d60031F2",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://www.trusttoken.com/truehkd",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": "QmbExpUA5ZocoXpqPBRLEeKp2VtQmq1KUSZPvPfeggCDd9"
+  },
+  "support": { "email": "support@trusttoken.com", "url": "" },
+  "social": {
+    "blog": "https://blog.trusttoken.com",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/trusttoken",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/TrustToken/",
+    "slack": "",
+    "telegram": "https://t.me/joinchat/HihkMkTja1gIyBRM1J1_vg",
+    "twitter": "https://twitter.com/TrustToken",
+    "youtube": ""
+  }
+}

--- a/src/tokens/eth/0x0000852600CEB001E08e00bC008be620d60031F2.json
+++ b/src/tokens/eth/0x0000852600CEB001E08e00bC008be620d60031F2.json
@@ -3,7 +3,7 @@
   "name": "TrueHKD",
   "type": "ERC20",
   "address": "0x0000852600CEB001E08e00bC008be620d60031F2",
-  "ens_address": "",
+  "ens_address": "truehkd.eth",
   "decimals": 18,
   "website": "https://www.trusttoken.com/truehkd",
   "logo": {


### PR DESCRIPTION

#### Changes
This documents THKD (TrueHKD).
#### Background
TrueHKD is built by TrustToken, the issuer of TrueUSD.
TrueHKD is fully-collateralized by HKD held by third-party trust companies.
TrustToken uses smart contracts to protect token supply and surfaces payment rails for you to easily convert between fiat and crypto.
Reviewers @gamalielhere