### PR TITLE
TrueCAD

### DIFF
--- a/src/tokens/eth/0x00000100F2A2bd000715001920eB70D229700085.json
+++ b/src/tokens/eth/0x00000100F2A2bd000715001920eB70D229700085.json
@@ -1,0 +1,31 @@
+{
+  "symbol": "TCAD",
+  "name": "TrueCAD",
+  "type": "ERC20",
+  "address": "0x00000100F2A2bd000715001920eB70D229700085",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://www.trusttoken.com/truecad",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": "Qmf5MMeVDxL5TGJ6fkyCxXnxZh9ZTVfRRkRJBWs3eDEkXf"
+  },
+  "support": { "email": "support@trusttoken.com", "url": "" },
+  "social": {
+    "blog": "https://blog.trusttoken.com",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/trusttoken",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/TrustToken/",
+    "slack": "",
+    "telegram": "https://t.me/joinchat/HihkMkTja1gIyBRM1J1_vg",
+    "twitter": "https://twitter.com/TrustToken",
+    "youtube": ""
+  }
+}

--- a/src/tokens/eth/0x00000100F2A2bd000715001920eB70D229700085.json
+++ b/src/tokens/eth/0x00000100F2A2bd000715001920eB70D229700085.json
@@ -3,7 +3,7 @@
   "name": "TrueCAD",
   "type": "ERC20",
   "address": "0x00000100F2A2bd000715001920eB70D229700085",
-  "ens_address": "",
+  "ens_address": "truecad.eth",
   "decimals": 18,
   "website": "https://www.trusttoken.com/truecad",
   "logo": {


### PR DESCRIPTION

#### Changes
This documents TCAD (TrueCAD).
#### Background
TrueCAD is built by TrustToken, the issuer of TrueUSD.
TrueCAD is fully-collateralized by CAD held by third-party trust companies.
TrustToken uses smart contracts to protect token supply and surfaces payment rails for you to easily convert between fiat and crypto.
Reviewers @gamalielhere