### PR TITLE
Add TrueAUD

### DIFF
--- a/src/tokens/eth/0x00006100F7090010005F1bd7aE6122c3C2CF0090.json
+++ b/src/tokens/eth/0x00006100F7090010005F1bd7aE6122c3C2CF0090.json
@@ -1,0 +1,31 @@
+{
+  "symbol": "TAUD",
+  "name": "TrueAUD",
+  "type": "ERC20",
+  "address": "0x00006100F7090010005F1bd7aE6122c3C2CF0090",
+  "ens_address": "trueaud.eth",
+  "decimals": 18,
+  "website": "https://www.trusttoken.com/trueaud",
+  "logo": {
+    "src": "",
+    "width": "",
+    "height": "",
+    "ipfs_hash": "QmTnCsfG8WX71q5GEysEN2oK2i98Az1avqE4jY7bfKYZQV"
+  },
+  "support": { "email": "support@trusttoken.com", "url": "" },
+  "social": {
+    "blog": "https://blog.trusttoken.com",
+    "chat": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/trusttoken",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/TrustToken/",
+    "slack": "",
+    "telegram": "https://t.me/joinchat/HihkMkTja1gIyBRM1J1_vg",
+    "twitter": "https://twitter.com/TrustToken",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION

#### Changes
This documents TrueAUD
#### Background
TrueAUD is built by TrustToken, the issuer of TrueUSD.
TrueAUD is fully-collateralized by AUD held by third-party trust companies.
TrustToken uses smart contracts to protect token supply and surfaces payment rails for you to easily convert between fiat and crypto.
Reviewer @gamalielhere