### PR TITLE
Add AMGO token

### DIFF
--- a/src/tokens/eth/0xf1aC7A375429719DE0dde33528e2639B9a206ebA.json
+++ b/src/tokens/eth/0xf1aC7A375429719DE0dde33528e2639B9a206ebA.json
@@ -1,0 +1,31 @@
+{
+  "symbol": "AMGO",
+  "name": "Arena Match Gold",
+  "type": "ERC20",
+  "address": "0xf1aC7A375429719DE0dde33528e2639B9a206ebA",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://arenamatch.com/amg",
+  "logo": {
+    "src": "https://arenamatch.com/img/amg256.png",
+    "width": "256",
+    "height": "256",
+    "ipfs_hash": ""
+  },
+  "support": { "email": "community@arenamatch.com", "url": "" },
+  "social": {
+    "blog": "https://steemit.com/@arenamatch",
+    "chat": "",
+    "facebook": "https://www.facebook.com/arenamatchgold/",
+    "forum": "",
+    "github": "https://github.com/arenamatch",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/ArenaMatch",
+    "twitter": "https://twitter.com/ArenaMatchGold",
+    "youtube": ""
+  }
+}


### PR DESCRIPTION
AMGO (“Arena Match Gold”) is a hyper-deflationary esports cryptocurrency token used for skill-based betting on popular PC games. AMGO will serve as a free utility token creating a decentralized, community-driven virtual economy. Each time AMGO is transferred 1% is burned and 1% is randomly given to the top 212 holders of AMGO.

Etherscan: https://etherscan.io/token/0xf1ac7a375429719de0dde33528e2639b9a206eba