### PR TITLE
Added LVN Token to Defaults

### DIFF
--- a/src/tokens/eth/0xc8cac7672f4669685817cf332a33eb249f085475.json
+++ b/src/tokens/eth/0xc8cac7672f4669685817cf332a33eb249f085475.json
@@ -1,0 +1,34 @@
+{
+  "symbol": "LVN",
+  "name": "LivenCoin",
+  "type": "ERC20",
+  "address": "0xc8cac7672f4669685817cf332a33eb249f085475",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://livenpay.io",
+  "logo": {
+    "src": "https://img.liven.com.au/external/myetherwallet_logo.png",
+    "width": "256px",
+    "height": "256px",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "info@liven.com.au",
+    "url": "https://help.liven.com.au"
+  },
+  "social": {
+    "blog": "https://blog.livenpay.io",
+    "chat": "",
+    "facebook": "https://www.facebook.com/LivenPay",
+    "forum": "",
+    "github": "https://github.com/livenpay",
+    "gitter": "",
+    "instagram": "https://www.instagram.com/livenpay",
+    "linkedin": "https://www.linkedin.com/company/liven",
+    "reddit": "https://www.reddit.com/r/LivenPay",
+    "slack": "",
+    "telegram": "https://t.me/livenpay",
+    "twitter": "https://twitter.com/livenpay",
+    "youtube": "https://www.youtube.com/user/livenaustralia"
+  }
+}


### PR DESCRIPTION
Hi,

[LVN](https://etherscan.io/token/0xc8cac7672f4669685817cf332a33eb249f085475) is issued by Liven, a rewards payment app in Australia with 500k+ users and 1k+ restaurant partners in Melbourne and Sydney.

The token will be listed on zb.com later this month ([announcement](https://www.zb.com/message/notice/267))

App: https://www.liven.com.au/
More about the token: https://livenpay.io/

-- Edit: Changed image size: 260x260 -> 256x256, force pushed for clean history.