### PR TITLE
Change OLD MNE Contract Address with NEW One

### DIFF
--- a/src/tokens/eth/0xc92e74b131D7b1D46E60e07F3FaE5d8877Dd03F0.js
+++ b/src/tokens/eth/0xc92e74b131D7b1D46E60e07F3FaE5d8877Dd03F0.js
@@ -1,0 +1,37 @@
+{
+"symbol": "MNE",
+
+"name": "Minereum",
+
+"type": "ERC20",
+
+"address": "0xc92e74b131D7b1D46E60e07F3FaE5d8877Dd03F0",
+"ens_address": "",
+"decimals": 8,
+"website": "https://www.minereum.com",
+"logo": {
+    "src": "https://www.minereum.com/mne.png",
+    "width": "",
+    "height": "",
+    "ipfs_hash": ""
+},
+"support": {
+    "email": "admin@minereum.com",
+    "url": ""
+},
+"social": {
+    "blog": "",
+    "chat": "",
+    "facebook": "",
+    "forum": "https://bitcointalk.org/index.php?topic=4495159",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "",
+    "slack": "",
+    "telegram": "https://t.me/minereumtoken",
+    "twitter": "https://twitter.com/minereumtoken",
+    "youtube": ""
+}
+}


### PR DESCRIPTION
There is already an existing MNE contract on myetherwallet (old one), please remove it and replace it with new contract.

MNE (Minereum) migrated to a new contract: 0xc92e74b131D7b1D46E60e07F3FaE5d8877Dd03F0
Old contract: 0x1a95b271b0535d15fa49932daba31ba612b52946 (DEPRECATED)

We already did the verification process on etherscan and you can verify that THE NEW minereum contract is 0xc92e74b131D7b1D46E60e07F3FaE5d8877Dd03F0 and there is a notification on the old contract etherscan page stating it was migrated to a new one: https://etherscan.io/token/0x1a95b271b0535d15fa49932daba31ba612b52946