### PR TITLE
update OCEAN contract

### DIFF
--- a/src/tokens/eth/0x967da4048cD07aB37855c090aAF366e4ce1b9F48.json
+++ b/src/tokens/eth/0x967da4048cD07aB37855c090aAF366e4ce1b9F48.json
@@ -2,12 +2,12 @@
   "symbol": "OCEAN",
   "name": "Ocean Token",
   "type": "ERC20",
-  "address": "0x7AFeBBB46fDb47ed17b22ed075Cde2447694fB9e",
+  "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
   "ens_address": "",
   "decimals": 18,
   "website": "https://oceanprotocol.com",
   "logo": {
-    "src": "https://raw.githubusercontent.com/oceanprotocol/art/master/logo/favicon-white.png",
+    "src": "https://raw.githubusercontent.com/oceanprotocol/art/master/logo/token.png",
     "width": "",
     "height": "",
     "ipfs_hash": ""


### PR DESCRIPTION
At [Ocean Protocol](https://oceanprotocol.com) we [moved to a new token contract today](https://blog.oceanprotocol.com/september-2020-hard-fork-ocean-token-completed-8142059361d7) following the KuCoin hack. This PR updates OCEAN to that new contract address.