### PR TITLE
MVP Contract Migration

### DIFF
--- a/src/tokens/eth/0x432a2c54de2dde941a36d2eb8c424ed666f74aef.json
+++ b/src/tokens/eth/0x432a2c54de2dde941a36d2eb8c424ed666f74aef.json
@@ -2,7 +2,7 @@
   "symbol": "MVP",
   "name": "Merculet",
   "type": "ERC20",
-  "address": "0x8a77e40936BbC27e80E9a3F526368C967869c86D",
+  "address": "0x432a2c54de2dde941a36d2eb8c424ed666f74aef",
   "ens_address": "",
   "decimals": 18,
   "website": "https://www.merculet.io",


### PR DESCRIPTION
This is the publisher of Merculet (MVP). The original contract address is 0x8a77e40936bbc27e80e9a3f526368c967869c86d. Our token is exchanged in kucoin. But kucoin was hacked in early October. All of the MVP was stolen. So we have to perform a hard fork. We created a new contract, and let our users to burn the MVP in old contract and give them same number of new contract token. Kucoin also migrate our token to new contract. This is the official announcement: https://twitter.com/Merculet_io/status/1316970985300594689?s=20

Ehterscan also migrated our token information to new contract: https://etherscan.io/token/0x432a2c54de2dde941a36d2eb8c424ed666f74aef

So we need to update the token file in MEW too