### PR TITLE
New contract for DNA token per announcement

### DIFF
--- a/src/tokens/eth/https:/github.com/MyEtherWallet/ethereum-lists/blob/master/src/tokens/eth/0xef6344de1fcfC5F48c30234C16c1389e8CdC572C.json
+++ b/src/tokens/eth/https:/github.com/MyEtherWallet/ethereum-lists/blob/master/src/tokens/eth/0xef6344de1fcfC5F48c30234C16c1389e8CdC572C.json
@@ -1,0 +1,27 @@
+{
+  "symbol": "DNA",
+  "name": "EncrypGen",
+  "type": "ERC20",
+  "address": "0xef6344de1fcfC5F48c30234C16c1389e8CdC572C",
+  "ens_address": "",
+  "decimals": 18,
+  "website": "https://encrypgen.com/",
+  "logo": { "src": "https://encrypgen.com/logo128x128.png", "width": "128", "height": "128", "ipfs_hash": "" },
+  "support": { "email": "info@encrypgen.com", "url": "" },
+  "social": {
+    "blog": "https://encrypgen.com/blog/",
+    "chat": "",
+    "discord": "",
+    "facebook": "https://www.facebook.com/encrypgen/",
+    "forum": "",
+    "github": "",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "https://www.linkedin.com/company/encrypgen-llc",
+    "reddit": "https://www.reddit.com/r/encrypgen",
+    "slack": "",
+    "telegram": "",
+    "twitter": "https://twitter.com/encrypgen",
+    "youtube": "https://www.youtube.com/channel/UC1qg5ZxwT4B2LNl8HUwj4NQ"
+  }
+}


### PR DESCRIPTION
This is a new contract address for EncrypGen DNA, per token swap announcement published on Etherscan, CoinGecko, and company blog.  Also creating a PR to update the deprecated token.  Announcements:
https://etherscan.io/token/0x82b0e50478eeafde392d45d1259ed1071b6fda81
https://www.coingecko.com/en/coins/encrypgen
https://encrypgen.com/the-big-dna-token-swap/