### PR TITLE
Add DOG token metadata to MEW Ethereum Lists

### DIFF
--- a/src/tokens/eth/0x131c1d2EEF8c4fd641A0eA487DaDCF33371346dD.json
+++ b/src/tokens/eth/0x131c1d2EEF8c4fd641A0eA487DaDCF33371346dD.json
@@ -1,0 +1,37 @@
+{
+  "symbol": "$DOG",
+  "name": "DOG",
+  "type": "ERC20",
+  "address": "0x131c1d2EEF8c4fd641A0eA487DaDCF33371346dD",
+  "ens_address": "dogcoincto.eth",
+  "decimals": 18,
+  "website": "https://www.dogcto.net/",
+  "logo": {
+    "src": "https://whalememe.github.io/dogcoincto/0x131c1d2eef8c4fd641a0ea487dadcf33371346dd.png",
+    "width": "256",
+    "height": "256",
+    "ipfs_hash": ""
+  },
+  "support": {
+    "email": "",
+    "url": ""
+  },
+  "social": {
+    "blog": "",
+    "chat": "",
+    "discord": "",
+    "facebook": "",
+    "forum": "",
+    "github": "https://github.com/Whalememe/dogcoincto",
+    "gitter": "",
+    "instagram": "",
+    "linkedin": "",
+    "reddit": "https://www.reddit.com/r/DogOnEth",
+    "slack": "",
+    "telegram": "https://t.me/DogtokenonETH",
+    "twitter": "https://twitter.com/dogcoincto",
+    "youtube": "https://www.youtube.com/channel/@DogCoin-q20"
+  }
+}
+
+


### PR DESCRIPTION
Added metadata for DOG token under `src/tokens/eth`. This includes:
- Token address: 0x131c1d2EEF8c4fd641A0eA487DaDCF33371346dD
- Token logo and description
- Social media links and other relevant details
